### PR TITLE
Use dynamic flatten in MNIST CNN

### DIFF
--- a/mnist.ipynb
+++ b/mnist.ipynb
@@ -48,7 +48,7 @@
     "        x = self.pool(F.relu(self.conv1(x)))\n",
     "        x = self.pool(F.relu(self.conv2(x)))\n",
     "        x = F.relu(self.conv3(x))\n",
-    "        x = x.view(-1, 128 * 7 * 7)\n",
+    "        x = torch.flatten(x, 1)\n",
     "        x = self.dropout(F.relu(self.fc1(x)))\n",
     "        x = self.fc2(x)\n",
     "        return x"


### PR DESCRIPTION
## Summary
- Flatten convolution outputs dynamically in `MNISTCNN.forward` to avoid hard-coded feature dimensions.
- Ensure fully connected layer expects the correct 128*7*7 features.

## Testing
- `python -m pytest`
- `python - <<'PY'
import torch
import torch.nn as nn
PY` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_688f8a810a0c83218b832c6378f19493