### PR TITLE
Add validation split and test evaluation

### DIFF
--- a/mnist.ipynb
+++ b/mnist.ipynb
@@ -20,7 +20,7 @@
     "import torch.nn.functional as F\n",
     "import torch.optim as optim\n",
     "from torchvision import datasets, transforms\n",
-    "from torch.utils.data import DataLoader\n",
+    "from torch.utils.data import DataLoader, random_split\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "from tqdm import tqdm"
@@ -66,10 +66,15 @@
     "    transforms.Normalize((0.1307,), (0.3081,))\n",
     "])\n",
     "\n",
-    "train_dataset = datasets.MNIST('./data', train=True, download=True, transform=transform)\n",
+    "train_dataset_full = datasets.MNIST('./data', train=True, download=True, transform=transform)\n",
     "test_dataset = datasets.MNIST('./data', train=False, transform=transform)\n",
     "\n",
+    "train_size = int(0.9 * len(train_dataset_full))\n",
+    "val_size = len(train_dataset_full) - train_size\n",
+    "train_dataset, val_dataset = random_split(train_dataset_full, [train_size, val_size])\n",
+    "\n",
     "train_loader = DataLoader(train_dataset, batch_size=128, shuffle=True)\n",
+    "val_loader = DataLoader(val_dataset, batch_size=128, shuffle=False)\n",
     "test_loader = DataLoader(test_dataset, batch_size=128, shuffle=False)"
    ]
   },
@@ -431,7 +436,7 @@
     "    total = 0\n",
     "    \n",
     "    with torch.no_grad():\n",
-    "        for data, target in test_loader:\n",
+    "        for data, target in val_loader:\n",
     "            data, target = data.to(device), target.to(device)\n",
     "            output = model(data)\n",
     "            _, predicted = torch.max(output.data, 1)\n",
@@ -456,6 +461,26 @@
     "            break\n",
     "\n",
     "print(f'Best accuracy: {best_acc:.2f}%')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5c7f6c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.eval()\n",
+    "test_correct = 0\n",
+    "test_total = 0\n",
+    "with torch.no_grad():\n",
+    "    for data, target in test_loader:\n",
+    "        data, target = data.to(device), target.to(device)\n",
+    "        output = model(data)\n",
+    "        _, predicted = torch.max(output.data, 1)\n",
+    "        test_total += target.size(0)\n",
+    "        test_correct += (predicted == target).sum().item()\n",
+    "print(f'Test accuracy: {100 * test_correct / test_total:.2f}%')"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- split the MNIST training set into train and validation subsets
- evaluate on validation data during training and test only after training

## Testing
- `pytest`
- `python - <<'PY' ...` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch torchvision -q` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f8a7f60bc83219542b9f56c54a9d5